### PR TITLE
Fix united landing page routing

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -59,6 +59,10 @@ ErrorDocument 404 /index.html
     Allow from all
 </Files>
 
+# Ensure /united-landing resolves to its index
+RewriteEngine On
+RewriteRule ^united-landing$ /united-landing/ [L,R=301]
+
 # Custom error pages (optional)
 # ErrorDocument 500 /error.html
 # ErrorDocument 403 /error.html 

--- a/united-landing/index.html
+++ b/united-landing/index.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+  <base href="/united-landing/">
   <meta name="theme-color" content="#005DAA">
   <title>United Airlines — Bookings, Changes, Cancellations | Call Now</title>
   <meta name="description" content="United Airlines phone support for flight bookings, itinerary changes, cancellations, baggage and more. Tap to call (844) 982-2596.">

--- a/vercel.json
+++ b/vercel.json
@@ -3,6 +3,10 @@
     {
       "source": "/terminix",
       "destination": "/terminix.html"
+    },
+    {
+      "source": "/united-landing",
+      "destination": "/united-landing/index.html"
     }
   ],
   "headers": [


### PR DESCRIPTION
Configure routing for `/united-landing` to correctly serve `index.html`.

Previously, `/united-landing` displayed a different page than `/united-landing/index.html`. This PR ensures `/united-landing` serves the correct `index.html` and resolves relative asset paths correctly.

---
<a href="https://cursor.com/background-agent?bcId=bc-67558c69-6c38-4228-8bcb-fb6325728a28">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-67558c69-6c38-4228-8bcb-fb6325728a28">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

