### PR TITLE
Fix united-landing mobile background and add ad tracking

### DIFF
--- a/united-landing/index.html
+++ b/united-landing/index.html
@@ -15,6 +15,29 @@
   <meta property="og:image" content="/assets/united-logo.png">
   <meta name="twitter:card" content="summary_large_image">
   <link rel="stylesheet" href="styles.css">
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=AW-697295426"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);} // eslint-disable-line
+    gtag('js', new Date());
+    gtag('config', 'AW-697295426');
+  </script>
+  <!-- Conversion event helper -->
+  <script>
+    function gtag_report_conversion(url) {
+      var callback = function () {
+        if (typeof(url) !== 'undefined') {
+          window.location = url;
+        }
+      };
+      gtag('event', 'conversion', {
+        'send_to': 'AW-697295426/H2cDCNC_pfEaEMLEv8wC',
+        'event_callback': callback
+      });
+      return false;
+    }
+  </script>
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -38,14 +61,14 @@
       <div class="brand">
         <img src="assets/united-logo.svg" onerror="this.onerror=null;this.src='assets/united-logo.png'" alt="United Airlines" class="logo" width="240" height="44">
       </div>
-      <a class="header-cta" href="tel:+18449822596" aria-label="Call United Airlines support (844) 982-2596">Call (844) 982-2596</a>
+      <a class="header-cta" href="tel:+18449822596" aria-label="Call United Airlines support (844) 982-2596" onclick="return gtag_report_conversion('tel:+18449822596');">Call (844) 982-2596</a>
     </header>
 
     <main class="content" role="main">
       <section class="hero" aria-label="United Airlines phone support">
         <h1 class="hero-title">Need help with your flight?</h1>
         <p class="hero-sub">Bookings • Changes • Cancellations • Baggage • Credits</p>
-        <a class="cta-primary" href="tel:+18449822596" aria-label="Tap to call United Airlines support, (844) 982-2596">
+        <a class="cta-primary" href="tel:+18449822596" aria-label="Tap to call United Airlines support, (844) 982-2596" onclick="return gtag_report_conversion('tel:+18449822596');">
           <span class="cta-icon" aria-hidden="true">📞</span>
           <span class="cta-text">Call Now</span>
           <span class="cta-num">(844) 982-2596</span>
@@ -92,7 +115,7 @@
       </section>
 
       <section class="inline-cta" aria-label="Quick call action">
-        <a class="cta-secondary" href="tel:+18449822596" aria-label="Call now (844) 982-2596">
+        <a class="cta-secondary" href="tel:+18449822596" aria-label="Call now (844) 982-2596" onclick="return gtag_report_conversion('tel:+18449822596');">
           <span class="cta-icon" aria-hidden="true">📞</span>
           <span class="cta-text">Call United Airlines</span>
           <span class="cta-num">(844) 982-2596</span>
@@ -104,7 +127,7 @@
       <p class="fineprint">Customer support for bookings, changes, cancellations, baggage, travel credits and general inquiries.</p>
     </footer>
 
-    <a class="sticky-call" href="tel:+18449822596" aria-label="Call now (844) 982-2596">
+    <a class="sticky-call" href="tel:+18449822596" aria-label="Call now (844) 982-2596" onclick="return gtag_report_conversion('tel:+18449822596');">
       <span class="sticky-icon" aria-hidden="true">📞</span>
       <span class="sticky-label">Call</span>
       <span class="sticky-num">(844) 982-2596</span>

--- a/united-landing/styles.css
+++ b/united-landing/styles.css
@@ -9,17 +9,23 @@
 }
 
 * { box-sizing: border-box; }
-html, body { height: 100%; }
+html, body { height: 100%; min-height: 100%; }
+
+html {
+  /* Ensure gradient covers viewport on mobile and behind fixed CTA */
+  background: linear-gradient(180deg, var(--rhapsody-blue) 0%, var(--united-blue) 100%);
+}
 
 body {
   margin: 0;
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, "Noto Sans", "Liberation Sans", sans-serif;
   color: var(--ink);
-  background: linear-gradient(180deg, var(--rhapsody-blue) 0%, var(--united-blue) 100%);
+  /* Fallback in case html background is overridden */
+  background: transparent;
 }
 
 .page {
-  min-height: 100dvh;
+  min-height: 100vh;
   display: flex;
   flex-direction: column;
 }
@@ -63,7 +69,7 @@ body {
 .header-cta:hover { filter: brightness(1.05); }
 
 /* Hero */
-.content { flex: 1; color: var(--white); padding-bottom: 96px; }
+.content { flex: 1; color: var(--white); padding-bottom: 96px; background: transparent; }
 @supports (padding: max(0px)) {
   .content { padding-bottom: max(96px, env(safe-area-inset-bottom)); }
 }
@@ -140,7 +146,7 @@ body {
 }
 
 /* Footer */
-.footer { padding: 16px 18px 80px; text-align: center; color: #c7d7f6; font-size: 12px; }
+.footer { padding: 16px 18px 80px; text-align: center; color: #c7d7f6; font-size: 12px; background: transparent; }
 
 /* Sticky CTA */
 .sticky-call {


### PR DESCRIPTION
Fixes mobile background gradient split and adds Google Ads conversion tracking to all CTA buttons.

The mobile background issue occurred because the gradient was applied to the `body` element, leading to inconsistent coverage and a visible split on some mobile devices. Moving the gradient to the `html` element ensures it consistently covers the entire viewport.

---
<a href="https://cursor.com/background-agent?bcId=bc-af445481-1683-4cf9-b8c7-7837fa451bb2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-af445481-1683-4cf9-b8c7-7837fa451bb2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

